### PR TITLE
Fixed label in 'Modify Interface' form for System Name.

### DIFF
--- a/application/views/interface/modify.php
+++ b/application/views/interface/modify.php
@@ -6,7 +6,7 @@
 		<div class="panel-body">
 			<form method="POST" id="modify-form">
 				<div class="form-group has-feedback">
-					<label class="control-label">Interface Name</label>
+					<label class="control-label">System Name</label>
 					<select name="systemName" class="form-control">
 						<?php
 						foreach($systems as $sys) {


### PR DESCRIPTION
When modifying a system interface, what should be the "System Name" dropdown is labeled as "Interface Name".
